### PR TITLE
Fix Refresh Token Scheduling Logic

### DIFF
--- a/src/hooks/Auth/useRefreshToken.ts
+++ b/src/hooks/Auth/useRefreshToken.ts
@@ -51,7 +51,7 @@ export const useRefreshToken = () => {
       const decoded = JSON.parse(atob(base64));
 
       const expirationTime = decoded.exp * 1000;
-      const refreshTime = expirationTime - 3 * 60 * 1000;
+      const refreshTime = expirationTime - 14 * 60 * 1000;
 
       return Math.max(refreshTime - Date.now(), 0);
     } catch (error) {
@@ -72,7 +72,7 @@ export const useRefreshToken = () => {
 
       return () => clearTimeout(timer);
     }
-  }, []);
+  }, [dispatch]);
 
   return { refreshAccessToken };
 };

--- a/src/hooks/Auth/useRefreshToken.ts
+++ b/src/hooks/Auth/useRefreshToken.ts
@@ -53,7 +53,7 @@ export const useRefreshToken = () => {
       const decoded = JSON.parse(atob(base64));
 
       const expirationTime = decoded.exp * 1000;
-      const refreshTime = expirationTime - 14 * 60 * 1000;
+      const refreshTime = expirationTime - 3 * 60 * 1000;
 
       return Math.max(refreshTime - Date.now(), 0);
     } catch (error) {


### PR DESCRIPTION
The previous implementation of the refresh token hooks only scheduled a refresh token API call during the first token exchange. This caused issues with token management over time. The issue has been addressed by ensuring that a refresh is scheduled immediately after each successful token exchange.  

### Adjustments Made:
1. **Initial Setup**: The hook now sets up the first token refresh upon mounting.  
2. **Automatic Rescheduling**: After every successful token refresh, the next refresh is automatically scheduled.  
3. **Termination Conditions**: The refresh cycle will stop under any of the following conditions:
   - A refresh attempt fails (clearing the token).  
   - The component unmounts.  
   - The user logs out.