### PR TITLE
Add Account Deletion Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ When you visit the login page, you can choose to register if you don’t have an
 
 ### 5.3 Role-Based Access Controls
 
-Once logged in, you can click on your avatar icon (which will usually be a rocket emoji) to change your password, view followed threads, or log out. Moderators will have additional buttons to ban users, and admins will have another button to assign moderators. These actions work by toggling; for example, if a user is not banned, clicking the button will ban them, and vice versa. A username is required to perform these actions.
+Once logged in, you can click on your avatar icon (which will usually be a rocket emoji) to change your password, view followed threads, or log out. Moderators will have additional buttons to ban users, and admins will have another button to assign moderators. These actions work by toggling; for example, if a user is not banned, clicking the button will ban them, and vice versa. A username is required to perform these actions. Banned users are not allowed to interact with the website and have the same level of accessibility as the unauthenticated users.
 
 **Note**: In this app, there is no functionality to assign an admin. The admin with the highest authority is assigned by directly editing their role in the database (refer to the [backend repo](https://github.com/oadultradeepfield/olympliance-backend)).
 

--- a/src/components/Category/ThreadCard.tsx
+++ b/src/components/Category/ThreadCard.tsx
@@ -19,7 +19,10 @@ export const ThreadCard: React.FC<ThreadCardProps> = ({
       <div className="card-body flex flex-row items-start p-3">
         {thread.user && (
           <div className="mr-2 mt-1">
-            <ReputationBadge reputation={thread.user.reputation} />
+            <ReputationBadge
+              reputation={thread.user.reputation}
+              is_deleted={thread.user.is_deleted}
+            />
           </div>
         )}
         <div className="flex flex-grow flex-col">

--- a/src/components/Category/ThreadStats.tsx
+++ b/src/components/Category/ThreadStats.tsx
@@ -45,7 +45,7 @@ const ThreadStats: React.FC<ThreadStatsProps> = ({
       {user && (
         <div className="flex items-center space-x-1">
           <span>
-            Author: {user.username}
+            Author: {user.is_deleted ? "[Deleted User]" : user.username}
             {badge && (
               <span className="ml-1 text-xs">
                 ({badge.title}: {user.reputation})

--- a/src/components/Comment/CommentCard.tsx
+++ b/src/components/Comment/CommentCard.tsx
@@ -34,7 +34,10 @@ const CommentCard: React.FC<CommentCardProps> = ({
   return (
     <div className="card mx-auto mb-3 flex w-full max-w-5xl border-2 border-base-content/15 bg-base-100 px-2 py-1">
       <div className="card-body flex flex-row items-start space-x-2 p-3">
-        <ReputationBadge reputation={reputation} />
+        <ReputationBadge
+          reputation={reputation}
+          is_deleted={comment.user?.is_deleted || false}
+        />
         <CommentContent
           threadId={threadId}
           badge={badge}

--- a/src/components/Comment/CommentInteractionAndStats.tsx
+++ b/src/components/Comment/CommentInteractionAndStats.tsx
@@ -65,7 +65,8 @@ const CommentInteractionAndStats: React.FC<CommentInteractionAndStatsProps> = ({
       </div>
       <div className="flex items-center space-x-1">
         <span>
-          Author: {comment.user?.username}
+          Author:{" "}
+          {comment.user?.is_deleted ? "[Deleted User]" : comment.user?.username}
           {badge && (
             <span className="ml-1 text-xs">
               ({badge.title}: {comment.user?.reputation})

--- a/src/components/Common/ReputationBadge.tsx
+++ b/src/components/Common/ReputationBadge.tsx
@@ -2,10 +2,14 @@ import { getBadge } from "../../utils/getBadge";
 
 interface ReputationBadgeProps {
   reputation: number;
+  is_deleted: boolean;
 }
 
-const ReputationBadge: React.FC<ReputationBadgeProps> = ({ reputation }) => {
-  const badge = getBadge(reputation);
+const ReputationBadge: React.FC<ReputationBadgeProps> = ({
+  reputation,
+  is_deleted,
+}) => {
+  const badge = is_deleted ? getBadge(0) : getBadge(reputation);
 
   if (!badge) return null;
 

--- a/src/components/Header/UserDropdown.tsx
+++ b/src/components/Header/UserDropdown.tsx
@@ -34,6 +34,11 @@ const UserDropdown = () => {
           <Link to="/change-password">Change Password</Link>
         </li>
         <li>
+          <Link to="/delete-account" className="text-error">
+            Delete Account
+          </Link>
+        </li>
+        <li>
           <button onClick={handleLogout}>Logout</button>
         </li>
       </ul>

--- a/src/components/Header/UserDropdown.tsx
+++ b/src/components/Header/UserDropdown.tsx
@@ -11,7 +11,10 @@ const UserDropdown = () => {
   return (
     <div className="dropdown dropdown-end" tabIndex={0}>
       <button className="avatar mr-0 p-0 sm:mr-3">
-        <ReputationBadge reputation={user.reputation} />
+        <ReputationBadge
+          reputation={user.reputation}
+          is_deleted={user.is_deleted}
+        />
       </button>
       <ul className="menu dropdown-content menu-sm z-[1] mt-2 w-52 rounded-box bg-base-200 p-2 shadow">
         {user.role_id > 0 && (

--- a/src/components/Header/UserDropdown.tsx
+++ b/src/components/Header/UserDropdown.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { RootState } from "../../store";
 import ReputationBadge from "../Common/ReputationBadge";
@@ -7,6 +7,13 @@ import { useLogout } from "../../hooks/Auth/useLogout";
 const UserDropdown = () => {
   const { user } = useSelector((state: RootState) => state.auth);
   const { handleLogout } = useLogout();
+
+  const navigate = useNavigate();
+
+  const handleLogoutAndRedirect = () => {
+    handleLogout();
+    navigate("/");
+  };
 
   return (
     <div className="dropdown dropdown-end" tabIndex={0}>
@@ -42,7 +49,7 @@ const UserDropdown = () => {
           </Link>
         </li>
         <li>
-          <button onClick={handleLogout}>Logout</button>
+          <button onClick={handleLogoutAndRedirect}>Logout</button>
         </li>
       </ul>
     </div>

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,15 +1,26 @@
 import Header from "../Header/Header";
 import Footer from "../Footer/Footer";
+import { useSelector } from "react-redux";
+import { RootState } from "../../store";
 
 interface AppLayoutProps {
   children: React.ReactNode;
 }
 
 const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
+  const { user } = useSelector((state: RootState) => state.auth);
+
   return (
     <div className="flex min-h-screen flex-col">
-      <div className="sticky top-0 z-[50] border-b-2 border-base-content/15 bg-base-100/50 backdrop-blur-md">
-        <Header />
+      <div className="sticky top-0 z-[50]">
+        <div className="border-b-2 border-base-content/15 bg-base-100/50 backdrop-blur-md">
+          <Header />
+        </div>
+        {user?.is_banned && (
+          <div className="bg-red-500 p-2 text-center text-white">
+            You have been banned and cannot interact with the website.
+          </div>
+        )}
       </div>
       <div className="flex flex-grow">{children}</div>
       <Footer />

--- a/src/components/Leaderboard/LeaderboardUserinfo.tsx
+++ b/src/components/Leaderboard/LeaderboardUserinfo.tsx
@@ -12,7 +12,7 @@ const LeaderboardUserInfo: React.FC<LeaderboardUserInfoProps> = ({ user }) => {
   return (
     <div className="flex items-center gap-3">
       <div className="avatar">
-        <ReputationBadge reputation={user.reputation} />
+        <ReputationBadge reputation={user.reputation} is_deleted={false} />
       </div>
       <div className="min-w-0 flex-1">
         <div className="max-w-[20ch] truncate font-bold md:max-w-[40ch]">

--- a/src/components/Thread/ThreadContent.tsx
+++ b/src/components/Thread/ThreadContent.tsx
@@ -30,7 +30,8 @@ const ThreadContent: React.FC<ThreadContentProps> = ({
       </div>
       <div className="mb-3 text-base text-base-content/75">
         <span>
-          By {thread.user?.username}
+          By{" "}
+          {thread.user?.is_deleted ? "[Deleted User]" : thread.user?.username}
           {badge && (
             <span className="ml-1 text-sm">
               ({badge.title}: {thread.user?.reputation})

--- a/src/data/userData.ts
+++ b/src/data/userData.ts
@@ -4,4 +4,5 @@ export interface UserInfo {
   reputation: number;
   role_id: number;
   is_banned: boolean;
+  is_deleted: boolean;
 }

--- a/src/hooks/Auth/useAuth.ts
+++ b/src/hooks/Auth/useAuth.ts
@@ -27,6 +27,7 @@ export const useAuth = () => {
               role_id: userResponse.data.role_id,
               reputation: userResponse.data.reputation,
               is_banned: userResponse.data.is_banned,
+              is_deleted: userResponse.data.is_deleted,
             },
           }),
         );
@@ -40,6 +41,7 @@ export const useAuth = () => {
               user_id: 0,
               username: "",
               is_banned: false,
+              is_deleted: false,
             },
           }),
         );

--- a/src/hooks/Auth/useAuthForm.ts
+++ b/src/hooks/Auth/useAuthForm.ts
@@ -51,6 +51,7 @@ export const useAuthForm = () => {
             role_id: userResponse.data.role_id,
             reputation: userResponse.data.reputation,
             is_banned: userResponse.data.is_banned,
+            is_deleted: userResponse.data.is_deleted,
           },
         }),
       );

--- a/src/hooks/Auth/useDeleteAccount.ts
+++ b/src/hooks/Auth/useDeleteAccount.ts
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import axios from "axios";
+import { apiUrl } from "../../data/apiUrl";
+import { useLogout } from "./useLogout";
+
+interface UseDeleteAccountResult {
+  deleteAccount: () => void;
+  error: string;
+  success: string;
+}
+
+export const useDeleteAccount = (): UseDeleteAccountResult => {
+  const [error, setError] = useState<string>("");
+  const [success, setSuccess] = useState<string>("");
+
+  const { handleLogout } = useLogout();
+
+  const deleteAccount = async () => {
+    setError("");
+    setSuccess("");
+
+    try {
+      const response = await axios.delete(`${apiUrl}/api/users/delete`);
+
+      setSuccess(response.data.message || "Account deleted successfully!");
+      setTimeout(() => {
+        setSuccess("");
+        handleLogout();
+      }, 1000);
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.error ||
+        "An unknown error occurred while deleting the account. Please try again.";
+      setError(errorMessage);
+    }
+  };
+
+  return {
+    deleteAccount,
+    error,
+    success,
+  };
+};

--- a/src/pages/Auth/DeleteAccount.tsx
+++ b/src/pages/Auth/DeleteAccount.tsx
@@ -37,7 +37,7 @@ const DeleteAccount: React.FC = () => {
 
   return (
     <div className="mx-auto flex max-w-5xl flex-grow flex-col items-center justify-center px-4 py-12">
-      <div className="w-96 rounded-lg border-2 border-base-content/15 bg-base-100 p-6">
+      <div className="w-96 rounded-xl border-2 border-base-content/15 bg-base-100 p-6">
         <h2 className="mb-6 text-2xl font-bold text-error">Delete Account</h2>
         <div className="space-y-4">
           <div>
@@ -59,7 +59,7 @@ const DeleteAccount: React.FC = () => {
           </p>
 
           <button
-            className={`btn w-full rounded-lg ${isValidConfirmation ? "btn-error" : "btn-outline btn-error cursor-not-allowed"}`}
+            className={`btn w-full rounded-lg ${isValidConfirmation ? "btn-error" : "btn-outline btn-error"}`}
             onClick={handleDeleteAccount}
             disabled={!isValidConfirmation}
           >

--- a/src/pages/Auth/DeleteAccount.tsx
+++ b/src/pages/Auth/DeleteAccount.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { RootState } from "../../store";
+import { MessageDisplay } from "../../components/Common/MessageDisplay";
+import { useDeleteAccount } from "../../hooks/Auth/useDeleteAccount";
+
+const DeleteAccount: React.FC = () => {
+  const isAuthenticated = useSelector(
+    (state: RootState) => state.auth.isAuthenticated,
+  );
+  const navigate = useNavigate();
+  const { deleteAccount, error, success } = useDeleteAccount();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate("/login");
+    }
+  }, [isAuthenticated, navigate]);
+
+  const handleDeleteAccount = () => {
+    deleteAccount();
+    setTimeout(() => {
+      navigate("/");
+    }, 1000);
+  };
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-grow flex-col items-center justify-center px-4 py-12">
+      <div className="card w-96 border-2 border-base-content/15 bg-base-100">
+        <div className="card-body items-center text-center">
+          <h2 className="card-title mb-4 text-2xl">Delete Account</h2>
+          {!isDeleting ? (
+            <div className="w-full">
+              <p className="mb-4 text-sm text-error">
+                Deleting your account is irreversible. All your data will be
+                permanently removed.
+              </p>
+              <button
+                className="btn btn-error w-full"
+                onClick={() => setIsDeleting(true)}
+              >
+                Delete Account
+              </button>
+            </div>
+          ) : (
+            <div className="modal w-96">
+              <h3 className="text-lg font-bold">Confirm Deletion</h3>
+              <p className="pt-4">
+                Are you sure you want to delete your account? This action cannot
+                be undone.
+              </p>
+              <div className="modal-action mt-4 flex justify-between">
+                <button className="btn" onClick={() => setIsDeleting(false)}>
+                  Cancel
+                </button>
+                <button className="btn btn-error" onClick={handleDeleteAccount}>
+                  Confirm
+                </button>
+              </div>
+            </div>
+          )}
+
+          {error && <MessageDisplay message={error} type="error" />}
+          {success && <MessageDisplay message={success} type="success" />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteAccount;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -14,6 +14,7 @@ import { RootState } from "../store";
 import ChangeUsername from "../pages/Auth/ChangeUsername";
 import Terms from "../pages/Terms/Terms";
 import Policy from "../pages/Terms/Policy";
+import DeleteAccount from "../pages/Auth/DeleteAccount";
 
 const AppRoutes = () => {
   const isAuthenticated = useSelector(
@@ -32,6 +33,7 @@ const AppRoutes = () => {
       <Route path="/followed-threads" element={<FollowedThreads />} />
       <Route path="/change-username" element={<ChangeUsername />} />
       <Route path="/change-password" element={<ChangePassword />} />
+      <Route path="/delete-account" element={<DeleteAccount />} />
       <Route path="/ban-user" element={<BanUserPage />} />
       <Route path="/assign-moderator" element={<AssignModeratorPage />} />
       <Route path="/:categoryTitle/new" element={<NewThread />} />

--- a/src/slices/authSlice.ts
+++ b/src/slices/authSlice.ts
@@ -16,6 +16,7 @@ const initialState: AuthState = {
     user_id: 0,
     username: "",
     is_banned: false,
+    is_deleted: false,
   },
 };
 
@@ -49,6 +50,7 @@ const authSlice = createSlice({
         user_id: 0,
         username: "",
         is_banned: false,
+        is_deleted: false,
       };
       state.isUserDataLoaded = false;
     },


### PR DESCRIPTION
This PR introduces a new feature allowing users to delete their accounts. Account deletion is implemented as a soft-delete, meaning the account remains in the database but the user will no longer be able to log in. Threads and comments created by deleted users will display as "[Deleted User]," and their usernames will no longer appear in the leaderboard.

Additionally, this PR extends similar behavior to banned users. A red banner will be displayed under the header to indicate a banned status, and banned users will also be unable to log in.